### PR TITLE
Fixed some  Qt5.15 MinGW GCC 11 build issues

### DIFF
--- a/modelexporters/excelexporter/excelexporter.pro
+++ b/modelexporters/excelexporter/excelexporter.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 QT += core widgets
-win32-msvc*|win32-icc: QT += axcontainer
+win32-msvc*|win32-icc|win32-g++: QT += axcontainer
 
 TEMPLATE = lib
 CONFIG += plugin

--- a/qtsqlextra/src/qtsqlutils.cpp
+++ b/qtsqlextra/src/qtsqlutils.cpp
@@ -1,6 +1,11 @@
 #include "qtsqlutils.h"
 #include <QObject>
 #include <QtSql>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include <sql.h>
 #include <sqlext.h>
 #include <sqlucode.h>

--- a/qtwidgetsextra/src/mainwindow/qtdockwidget.h
+++ b/qtwidgetsextra/src/mainwindow/qtdockwidget.h
@@ -13,8 +13,8 @@ class QTWIDGETSEXTRA_EXPORT QtDockWidget :
     Q_PROPERTY(bool autoHide READ isAutoHide WRITE setAutoHide)
 
 public:
-    explicit QtDockWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
-    explicit QtDockWidget(const QString& title, QWidget *parent = 0, Qt::WindowFlags f = 0);
+    explicit QtDockWidget(QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
+    explicit QtDockWidget(const QString& title, QWidget *parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
     ~QtDockWidget();
 
     bool isAutoHide() const;

--- a/qtwidgetsextra/src/painting/qtpaintutils.cpp
+++ b/qtwidgetsextra/src/painting/qtpaintutils.cpp
@@ -1,5 +1,6 @@
 #include "qtpaintutils.h"
 
+
 inline void __drawCircularText(QPainter& painter, const QString &text, const QPainterPath &path, qreal stretch, qreal start, qreal factor)
 {
     QPen pen = painter.pen();

--- a/qtwidgetsextra/src/painting/qtpaintutils.h
+++ b/qtwidgetsextra/src/painting/qtpaintutils.h
@@ -6,6 +6,7 @@
 #include <QtWidgetsExtra>
 
 #include <QPainter>
+#include <QPainterPath>
 
 
 class QTWIDGETSEXTRA_EXPORT QtPainter :

--- a/qtwidgetsextra/src/widgets/qtcardwidget.cpp
+++ b/qtwidgetsextra/src/widgets/qtcardwidget.cpp
@@ -1,6 +1,7 @@
 #include "qtcardwidget.h"
 #include <QVariant>
 #include <QPainter>
+#include <QPainterPath>
 #include <cstring>
 #include <cstdlib>
 

--- a/qtwidgetsextra/src/widgets/qtcolorgrid.cpp
+++ b/qtwidgetsextra/src/widgets/qtcolorgrid.cpp
@@ -1,6 +1,7 @@
 #include <QApplication>
 #include <QStyle>
 #include <QPainter>
+#include <QMouseEvent>
 
 #include <QDebug>
 


### PR DESCRIPTION
This pull request fixes some buils issues when building the library with Qt5.15 and MinGW GCC 11. With this fix it is possible to build at least 

- qtcoreextra
- qtplugins
- qtpropertybrowser
- qtwidgetsextra
- modelexporters

The build of **qtsqlextra** still fails because the **libodbc** is not found when linking the library.